### PR TITLE
Fix for out of CPU errors during CP100 class

### DIFF
--- a/guestbook.yaml
+++ b/guestbook.yaml
@@ -18,7 +18,21 @@ spec:
         image: google/guestbook-python-redis
         ports:
         - containerPort: 80
+        resources:
+          requests:
+            memory: ".5Gi"
+            cpu: "25m"
+          limits:
+            memory: "1Gi"
+            cpu: "50m"
       - name: redis
         image: redis
         ports:
         - containerPort: 6379
+        resources:
+          requests:
+            memory: ".5Gi"
+            cpu: "25m"
+          limits:
+            memory: "1Gi"
+            cpu: "50m"


### PR DESCRIPTION
Running on a single standard instance (1CPU/3.75gb) will fail (didn't investigate why) - maybe because of other processes running due to ssh via GCP web UI.
Applying hard limits to the processes works as a crappy workaround for this issue.
